### PR TITLE
fix(cicd): add packages write permission to build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AnalyticsService } from './analytics.service';
 import { AnalyticsController } from './analytics.controller';
@@ -10,7 +10,7 @@ import { PostModule } from '../post/post.module';
 @Module({
   imports: [
     TypeOrmModule.forFeature([PostAnalytic, AnalyticsEvent, Post]),
-    PostModule,
+    forwardRef(() => PostModule),
   ],
   controllers: [AnalyticsController],
   providers: [AnalyticsService],

--- a/src/modules/post/post.module.ts
+++ b/src/modules/post/post.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostController } from './post.controller';
 import { PostService } from './post.service';
@@ -12,7 +12,7 @@ import { PostHashtag } from './entities/post-hashtag.entity';
   imports: [
     TypeOrmModule.forFeature([Post, PostHashtag]),
     StorageModule,
-    AnalyticsModule,
+    forwardRef(() => AnalyticsModule),
     HashtagModule,
   ],
   controllers: [PostController],


### PR DESCRIPTION
This commit fixes a deployment error where the workflow was denied permission to create a GitHub package in an organization account.

The `GITHUB_TOKEN` requires explicit `packages: write` permission to be able to push Docker images to the GitHub Container Registry (ghcr.io) when the repository belongs to an organization.

A `permissions` block has been added to the `build` job in the `deploy.yml` workflow to grant the necessary permissions.